### PR TITLE
[ WorkDetail ] 작업 상세 뷰 퍼블리싱

### DIFF
--- a/src/DesktopRouter.tsx
+++ b/src/DesktopRouter.tsx
@@ -3,11 +3,13 @@ import DesignersPage from './desktop/Designers/pages/DesignersPage';
 import DisplayPages from './desktop/Displays/pages/DisplayPages';
 import MainPage from './desktop/Main/pages/MainPage';
 import StudioPage from './desktop/Studio/pages/StudioPage';
+import WorkDetailPage from './desktop/WorkDetail/pages/WorkDetailPage';
 import WorksPage from './desktop/Works/pages/WorksPage';
 
 const router = createBrowserRouter([
   { path: '/', element: <MainPage /> },
   { path: '/:currentUrl', element: <StudioPage /> },
+  { path: '/:currentUrl/:workId', element: <WorkDetailPage /> },
   { path: '/works', element: <WorksPage /> },
   { path: '/designers', element: <DesignersPage /> },
   { path: '/displays', element: <DisplayPages /> },

--- a/src/desktop/Studio/components/TotalWorks.tsx
+++ b/src/desktop/Studio/components/TotalWorks.tsx
@@ -228,6 +228,7 @@ const title = (isHoveredImg: boolean) => css`
 
 const designerNameContainer = css`
   display: flex;
+  gap: 0.8rem;
   align-items: center;
 `;
 

--- a/src/desktop/Studio/components/TotalWorks.tsx
+++ b/src/desktop/Studio/components/TotalWorks.tsx
@@ -1,11 +1,13 @@
 import { css } from '@emotion/react';
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { colors, fonts } from '../../../styles/theme';
 import { TotalWorksProps } from '../types/studioType';
 
 const DUMMY = {
   works: [
     {
+      url: '1',
       workTitle: '제목 1',
       images: [
         {
@@ -28,6 +30,7 @@ const DUMMY = {
       ],
     },
     {
+      url: '2',
       workTitle: '제목 2',
       images: [
         {
@@ -43,6 +46,7 @@ const DUMMY = {
       ],
     },
     {
+      url: '3',
       workTitle: '제목 3',
       images: [
         {
@@ -58,6 +62,7 @@ const DUMMY = {
       ],
     },
     {
+      url: '4',
       workTitle: '제목 4',
       images: [
         {
@@ -81,6 +86,7 @@ const DUMMY = {
       ],
     },
     {
+      url: '5',
       workTitle: '제목 5',
       images: [
         {
@@ -96,6 +102,7 @@ const DUMMY = {
       ],
     },
     {
+      url: '6',
       workTitle: '제목 6',
       images: [
         {
@@ -153,30 +160,32 @@ const TotalWorks = ({ id }: TotalWorksProps) => {
   return (
     <article css={worksContainer}>
       {works.map((work) => {
-        const { workTitle, images, designers } = work;
+        const { workTitle, images, designers, url } = work;
         const { imgPath } = images[0];
         const isHoveredGif = hoveredSrc && workTitle === hovredTitle;
         const isHoveredImg = workTitle === hovredTitle;
 
         return (
           <article key={workTitle} css={workContainer}>
-            <img
-              src={isHoveredGif ? hoveredSrc : imgPath}
-              css={workImg}
-              onMouseEnter={() => handleHoverImg(images, workTitle)}
-              onMouseLeave={handleLeaveImg}
-            />
-            <p css={title(isHoveredImg)}>{workTitle}</p>
-            <div css={designerNameContainer}>
-              {designers.map((designer) => {
-                const { name } = designer;
-                return (
-                  <p key={name} css={designerName(isHoveredImg)}>
-                    {name}
-                  </p>
-                );
-              })}
-            </div>
+            <Link to={url}>
+              <img
+                src={isHoveredGif ? hoveredSrc : imgPath}
+                css={workImg}
+                onMouseEnter={() => handleHoverImg(images, workTitle)}
+                onMouseLeave={handleLeaveImg}
+              />
+              <p css={title(isHoveredImg)}>{workTitle}</p>
+              <div css={designerNameContainer}>
+                {designers.map((designer) => {
+                  const { name } = designer;
+                  return (
+                    <p key={name} css={designerName(isHoveredImg)}>
+                      {name}
+                    </p>
+                  );
+                })}
+              </div>
+            </Link>
           </article>
         );
       })}
@@ -203,7 +212,8 @@ const workImg = css`
   min-height: 30.6rem;
 
   width: 100%;
-  height: 100%;
+  aspect-ratio: 1 / 1;
+
   margin-bottom: calc(100vh / 67.5);
 
   object-fit: cover;

--- a/src/desktop/WorkDetail/components/Designers.tsx
+++ b/src/desktop/WorkDetail/components/Designers.tsx
@@ -1,0 +1,170 @@
+import { css } from '@emotion/react';
+import { useState } from 'react';
+import { colors, fonts } from '../../../styles/theme';
+
+interface DesignersProps {
+  designers: Array<{
+    name: string;
+    engName: string;
+    email: string;
+    workTitle: string;
+    studioNm: string;
+    images: Array<{ imgPath: string; fileFormat: string }>;
+  }>;
+}
+
+const Designers = ({ designers }: DesignersProps) => {
+  const [hoveredImg, setHoveredImg] = useState({
+    hoveredTitle: '',
+    hoveredName: '',
+  });
+
+  const { hoveredName, hoveredTitle } = hoveredImg;
+
+  const handleHoverImg = (workTitle: string, name: string) => {
+    setHoveredImg({
+      hoveredTitle: workTitle,
+      hoveredName: name,
+    });
+  };
+
+  const handleLeaveImg = () => {
+    setHoveredImg({
+      hoveredTitle: '',
+      hoveredName: '',
+    });
+  };
+
+  return (
+    <article css={designedByContainer}>
+      <p css={designedByTitle}>Designed by</p>
+      <div css={totalDesigners}>
+        {designers.map((designer) => {
+          const { name, engName, email, workTitle, studioNm, images } =
+            designer;
+          const { imgPath, fileFormat } =
+            images.length > 1 ? images[1] : images[0];
+          const isStaticImg = fileFormat !== 'gif';
+          const isHoveredImg =
+            hoveredTitle === workTitle && hoveredName === name;
+
+          return (
+            <article key={name} css={designerInfoContainer}>
+              <div css={designerInfo}>
+                <p css={designerKrName}>{name}</p>
+                <p css={designerEngName}>{engName}</p>
+                <p css={designerEmail}>{email}</p>
+              </div>
+              <img
+                src={imgPath}
+                css={designersWork(isHoveredImg)}
+                onMouseEnter={() =>
+                  isStaticImg && handleHoverImg(workTitle, name)
+                }
+                onMouseLeave={handleLeaveImg}
+              />
+
+              {isHoveredImg && (
+                <div css={hoveredInfo}>
+                  <p css={hoveredWorkTitle}>{workTitle}</p>
+                  <p css={hoveredStudioNm}>{studioNm}</p>
+                </div>
+              )}
+            </article>
+          );
+        })}
+      </div>
+    </article>
+  );
+};
+
+export default Designers;
+
+const designedByContainer = css`
+  display: flex;
+  gap: calc(100vh / 20.25);
+  flex-direction: column;
+
+  margin: calc(100vh / 8.1) 0 calc(100vh / 5.79) calc(100% / 24);
+`;
+
+const designedByTitle = css`
+  color: ${colors.gray900};
+  ${fonts.desktop_title_semi_28};
+`;
+
+const totalDesigners = css`
+  display: flex;
+  gap: calc(100% / 45);
+  align-items: center;
+`;
+
+const designerInfoContainer = css`
+  display: flex;
+  gap: calc(100vh / 50.6);
+  justify-content: center;
+  flex-direction: column;
+  position: relative;
+
+  min-width: 30.6rem;
+
+  width: calc(100% / 4.7);
+`;
+
+const designerInfo = css`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+`;
+
+const designerKrName = css`
+  margin-bottom: calc(100vh / 202.5);
+
+  color: ${colors.gray900};
+  ${fonts.desktop_body_semi_20};
+`;
+
+const designerEngName = css`
+  margin-bottom: calc(100vh / 101.25);
+
+  color: ${colors.gray900};
+  ${fonts.desktop_body_reg_18};
+`;
+
+const designerEmail = css`
+  color: ${colors.gray500};
+  ${fonts.desktop_body_reg_16};
+`;
+
+const designersWork = (isHoveredImg: boolean) => css`
+  min-height: 30.6rem;
+
+  width: 100%;
+  aspect-ratio: 1 / 1;
+
+  object-fit: cover;
+
+  ${isHoveredImg &&
+  css`
+    filter: brightness(0.5);
+  `}
+`;
+
+const hoveredInfo = css`
+  display: flex;
+  gap: calc(100vh / 202.5);
+  flex-direction: column;
+  position: absolute;
+  bottom: 1.6rem;
+  left: 1.6rem;
+`;
+
+const hoveredWorkTitle = css`
+  color: ${colors.white};
+  ${fonts.desktop_body_semi_20};
+`;
+
+const hoveredStudioNm = css`
+  color: ${colors.white};
+  ${fonts.desktop_body_reg_18};
+`;

--- a/src/desktop/WorkDetail/components/Designers.tsx
+++ b/src/desktop/WorkDetail/components/Designers.tsx
@@ -1,17 +1,7 @@
 import { css } from '@emotion/react';
 import { useState } from 'react';
 import { colors, fonts } from '../../../styles/theme';
-
-interface DesignersProps {
-  designers: Array<{
-    name: string;
-    engName: string;
-    email: string;
-    workTitle: string;
-    studioNm: string;
-    images: Array<{ imgPath: string; fileFormat: string }>;
-  }>;
-}
+import { DesignersProps } from '../types/workDetailTypes';
 
 const Designers = ({ designers }: DesignersProps) => {
   const [hoveredImg, setHoveredImg] = useState({

--- a/src/desktop/WorkDetail/components/DetailImages.tsx
+++ b/src/desktop/WorkDetail/components/DetailImages.tsx
@@ -1,0 +1,31 @@
+import { css } from '@emotion/react';
+
+interface DetailImagesProps {
+  images: Array<{
+    sort: number;
+    imgPath: string;
+  }>;
+}
+
+const DetailImages = ({ images }: DetailImagesProps) => {
+  return (
+    <article css={workImages}>
+      {images.map((image) => {
+        const { sort, imgPath } = image;
+        return <img key={sort} src={imgPath} css={workImg} />;
+      })}
+    </article>
+  );
+};
+
+export default DetailImages;
+
+const workImages = css`
+  padding: 0 calc(100% / 14.4);
+`;
+
+const workImg = css`
+  width: 100%;
+
+  object-fit: cover;
+`;

--- a/src/desktop/WorkDetail/components/DetailImages.tsx
+++ b/src/desktop/WorkDetail/components/DetailImages.tsx
@@ -1,11 +1,5 @@
 import { css } from '@emotion/react';
-
-interface DetailImagesProps {
-  images: Array<{
-    sort: number;
-    imgPath: string;
-  }>;
-}
+import { DetailImagesProps } from '../types/workDetailTypes';
 
 const DetailImages = ({ images }: DetailImagesProps) => {
   return (

--- a/src/desktop/WorkDetail/components/Details.tsx
+++ b/src/desktop/WorkDetail/components/Details.tsx
@@ -1,12 +1,6 @@
 import { css } from '@emotion/react';
 import { colors, fonts } from '../../../styles/theme';
-
-interface DetailsProps {
-  workTitle: string;
-  designers: Array<{ name: string }>;
-  workBody: string;
-  workEngBody: string;
-}
+import { DetailsProps } from '../types/workDetailTypes';
 
 const Details = ({
   workTitle,

--- a/src/desktop/WorkDetail/components/Details.tsx
+++ b/src/desktop/WorkDetail/components/Details.tsx
@@ -1,0 +1,94 @@
+import { css } from '@emotion/react';
+import { colors, fonts } from '../../../styles/theme';
+
+interface DetailsProps {
+  workTitle: string;
+  designers: Array<{ name: string }>;
+  workBody: string;
+  workEngBody: string;
+}
+
+const Details = ({
+  workTitle,
+  designers,
+  workBody,
+  workEngBody,
+}: DetailsProps) => {
+  return (
+    <article css={workDetail}>
+      <div css={workInfo}>
+        <p css={title}>{workTitle}</p>
+        <div css={designerContainer}>
+          {designers.map((designer) => {
+            const { name } = designer;
+            return (
+              <p key={name} css={designerName}>
+                {name}
+              </p>
+            );
+          })}
+        </div>
+      </div>
+      <div css={workDescription}>
+        <p css={krDesc}>{workBody}</p>
+        <p css={engDesc}>{workEngBody}</p>
+      </div>
+    </article>
+  );
+};
+
+export default Details;
+
+const workDetail = css`
+  display: flex;
+  gap: calc(100% / 26.19);
+  justify-content: center;
+
+  margin: calc(100vh / 10.125) calc(100% / 14.4) calc(100vh / 7.79);
+`;
+
+const workInfo = css`
+  display: flex;
+  gap: calc(100vh / 101.25);
+  flex-direction: column;
+
+  min-width: 41.1rem;
+`;
+
+const title = css`
+  color: ${colors.gray900};
+  ${fonts.desktop_title_semi_28};
+`;
+
+const designerContainer = css`
+  display: flex;
+  gap: calc(100vh / 101.25);
+  align-items: center;
+`;
+
+const designerName = css`
+  color: ${colors.gray900};
+  ${fonts.desktop_body_reg_20};
+`;
+
+const workDescription = css`
+  display: flex;
+  gap: calc(100vh / 33.75);
+  justify-content: center;
+  flex-direction: column;
+  flex-grow: 1;
+`;
+
+const krDesc = css`
+  color: ${colors.gray900};
+  ${fonts.desktop_body_reg_16};
+
+  white-space: pre-wrap;
+`;
+
+const engDesc = css`
+  color: ${colors.gray500};
+  ${fonts.desktop_body_lig_16};
+
+  white-space: pre-wrap;
+`;

--- a/src/desktop/WorkDetail/pages/WorkDetailPage.tsx
+++ b/src/desktop/WorkDetail/pages/WorkDetailPage.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { useState } from 'react';
 import { colors, fonts } from '../../../styles/theme';
 import PageLayout from '../../Common/PageLayout';
 
@@ -67,12 +68,48 @@ const DUMMY = {
         },
       ],
     },
+    {
+      name: '서아름',
+      engName: 'Areum Seo',
+      email: 'arooming123@gmail.com',
+      workTitle: '서비스 디자인',
+      studioNm: '디자인씽킹스튜디오',
+      images: [
+        {
+          imgPath:
+            'https://i.pinimg.com/236x/13/26/c1/1326c1f3ec2a54bfc0893a0c582360de.jpg',
+          fileFormat: 'jpeg',
+        },
+      ],
+    },
   ],
 };
 
 const WorkDetailPage = () => {
   const { workTitle, workBody, workEngBody, thumbnail, images, designers } =
     DUMMY;
+
+  const [hoveredImg, setHoveredImg] = useState({
+    hoveredTitle: '',
+    hoveredName: '',
+  });
+
+  const { hoveredName, hoveredTitle } = hoveredImg;
+
+  const handleHoverImg = (workTitle: string, name: string) => {
+    setHoveredImg({
+      hoveredTitle: workTitle,
+      hoveredName: name,
+    });
+  };
+
+  const handleLeaveImg = () => {
+    setHoveredImg({
+      hoveredTitle: '',
+      hoveredName: '',
+    });
+  };
+
   return (
     <PageLayout>
       <section css={workDetailContainer}>
@@ -110,15 +147,34 @@ const WorkDetailPage = () => {
             {designers.map((designer) => {
               const { name, engName, email, workTitle, studioNm, images } =
                 designer;
-              const { imgPath } = images.length > 1 ? images[1] : images[0];
+              const { imgPath, fileFormat } =
+                images.length > 1 ? images[1] : images[0];
+              const isStaticImg = fileFormat !== 'gif';
+              const isHoveredImg =
+                hoveredTitle === workTitle && hoveredName === name;
+
               return (
-                <article css={designerInfoContainer}>
+                <article key={name} css={designerInfoContainer}>
                   <div css={designerInfo}>
                     <p css={designerKrName}>{name}</p>
                     <p css={designerEngName}>{engName}</p>
                     <p css={designerEmail}>{email}</p>
                   </div>
-                  <img src={imgPath} css={designersWork} />
+                  <img
+                    src={imgPath}
+                    css={designersWork(isHoveredImg)}
+                    onMouseEnter={() =>
+                      isStaticImg && handleHoverImg(workTitle, name)
+                    }
+                    onMouseLeave={handleLeaveImg}
+                  ></img>
+
+                  {isHoveredImg && (
+                    <div css={hoveredInfo}>
+                      <p css={hoveredWorkTitle}>{workTitle}</p>
+                      <p css={hoveredStudioNm}>{studioNm}</p>
+                    </div>
+                  )}
                 </article>
               );
             })}
@@ -230,6 +286,7 @@ const designerInfoContainer = css`
   gap: 1.6rem;
   justify-content: center;
   flex-direction: column;
+  position: relative;
 `;
 
 const designerInfo = css`
@@ -257,7 +314,31 @@ const designerEmail = css`
   ${fonts.desktop_body_reg_16};
 `;
 
-const designersWork = css`
+const designersWork = (isHoveredImg: boolean) => css`
   width: 30.6rem;
   aspect-ratio: 1/1;
+
+  ${isHoveredImg &&
+  css`
+    filter: brightness(0.5);
+  `}
+`;
+
+const hoveredInfo = css`
+  display: flex;
+  gap: 0.4rem;
+  flex-direction: column;
+  position: absolute;
+  bottom: 1.6rem;
+  left: 1.6rem;
+`;
+
+const hoveredWorkTitle = css`
+  color: ${colors.white};
+  ${fonts.desktop_body_semi_20};
+`;
+
+const hoveredStudioNm = css`
+  color: ${colors.white};
+  ${fonts.desktop_body_reg_18};
 `;

--- a/src/desktop/WorkDetail/pages/WorkDetailPage.tsx
+++ b/src/desktop/WorkDetail/pages/WorkDetailPage.tsx
@@ -1,0 +1,263 @@
+import { css } from '@emotion/react';
+import { colors, fonts } from '../../../styles/theme';
+import PageLayout from '../../Common/PageLayout';
+
+const DUMMY = {
+  workTitle: '디지털 일러스트',
+  workBody:
+    '부정적인 감정이 들었을 때, 부정적인 상황이 생겼을 때 여러분들은 어떤 해결 방법을 가지고 있나요?\n저는 부정적인 감정과 상황을 완전히 해결하려고 하기보다는 일단은 덮어두고 그 감정과 상황을 회피하려는 성향이 있습니다.\n그리고 뭔가 긍정적인 감정과 상황으로 덮으려고 합니다.\n부정적인 감정과 상황을 긍정적인 감정과 상황으로 덮는 것을 엽서와 엽서를 덮는 필름에 시각화하여 표현하였습니다.',
+  workEngBody: `What kind of solution do you have when you feel negative emotions or when a negative situation occurs?\nRather than trying to solve negative emotions and situations completely, I tend to avoid them by hiding.  And I'm trying to cover it up with some positive emotions and situations.\nIt visualized negative emotions and situations covered with positive emotions and situations on film covering postcards and postcards.`,
+  thumbnail:
+    'https://mblogthumb-phinf.pstatic.net/20151231_18/kimtaeyon1_1451530246034U8P5X_PNG/%BF%A1%BA%F1%C3%F2%C2%A9_%282%29.png?type=w420',
+  images: [
+    {
+      sort: 1,
+      imgPath: 'https://cdn2.colley.kr/item_383431_1_0_title_0.jpeg',
+    },
+    {
+      sort: 2,
+      imgPath:
+        'https://i.pinimg.com/originals/99/7a/9b/997a9b2cd93277769ca9b3d109bceed7.jpg',
+    },
+    {
+      sort: 3,
+      imgPath: 'https://cdn2.colley.kr/item_127602_1_4_title_4.jpeg',
+    },
+    {
+      sort: 4,
+      imgPath:
+        'https://muko.kr/files/attach/images/2022/11/22/81725dc1572f2c88c1b2787db750735f.jpg',
+    },
+    {
+      sort: 5,
+      imgPath:
+        'https://i.pinimg.com/236x/2b/7b/dc/2b7bdc1b28064e8496bcc4e907cc87e3.jpg',
+    },
+  ],
+  designers: [
+    {
+      name: '양종욱',
+      engName: 'Jonguk Yang',
+      email: 'didwhddnr123@naver.com',
+      workTitle: '서비스 디자인',
+      studioNm: '디자인씽킹스튜디오',
+      images: [
+        {
+          imgPath: 'https://xen-api.linkareer.com/attachments/80334',
+          fileFormat: 'jpeg',
+        },
+        {
+          imgPath:
+            'https://i.pinimg.com/originals/a0/89/e7/a089e759d7e713b4eba7b6cda87b6c8a.gif',
+          fileFormat: 'gif',
+        },
+      ],
+    },
+    {
+      name: '김지훈',
+      engName: 'Jihun Kim',
+      email: 'jihun.kim@gmail.com',
+      workTitle: '서비스 디자인',
+      studioNm: '디자인씽킹스튜디오',
+      images: [
+        {
+          imgPath:
+            'https://i.pinimg.com/236x/13/26/c1/1326c1f3ec2a54bfc0893a0c582360de.jpg',
+          fileFormat: 'jpeg',
+        },
+      ],
+    },
+  ],
+};
+
+const WorkDetailPage = () => {
+  const { workTitle, workBody, workEngBody, thumbnail, images, designers } =
+    DUMMY;
+  return (
+    <PageLayout>
+      <section css={workDetailContainer}>
+        <img src={thumbnail} css={workThumbnail} />
+        <article css={workDetail}>
+          <div css={workInfo}>
+            <p css={title}>{workTitle}</p>
+            <div css={designerContainer}>
+              {designers.map((designer) => {
+                const { name } = designer;
+                return (
+                  <p key={name} css={designerName}>
+                    {name}
+                  </p>
+                );
+              })}
+            </div>
+          </div>
+          <div css={workDescription}>
+            <p css={krDesc}>{workBody}</p>
+            <p css={engDesc}>{workEngBody}</p>
+          </div>
+        </article>
+
+        <article css={workImages}>
+          {images.map((image) => {
+            const { sort, imgPath } = image;
+            return <img key={sort} src={imgPath} css={workImg} />;
+          })}
+        </article>
+
+        <article css={designedByContainer}>
+          <p css={designedByTitle}>Designed by</p>
+          <div css={totalDesigners}>
+            {designers.map((designer) => {
+              const { name, engName, email, workTitle, studioNm, images } =
+                designer;
+              const { imgPath } = images.length > 1 ? images[1] : images[0];
+              return (
+                <article css={designerInfoContainer}>
+                  <div css={designerInfo}>
+                    <p css={designerKrName}>{name}</p>
+                    <p css={designerEngName}>{engName}</p>
+                    <p css={designerEmail}>{email}</p>
+                  </div>
+                  <img src={imgPath} css={designersWork} />
+                </article>
+              );
+            })}
+          </div>
+        </article>
+      </section>
+    </PageLayout>
+  );
+};
+
+export default WorkDetailPage;
+
+const workDetailContainer = css`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+`;
+
+const workThumbnail = css`
+  width: 100%;
+  height: calc(100vh / 1.65);
+`;
+
+const workDetail = css`
+  display: flex;
+  gap: calc(100% / 26.19);
+  justify-content: center;
+
+  margin: calc(100vh / 10.125) calc(100% / 14.4) calc(100vh / 7.79);
+`;
+
+const workInfo = css`
+  display: flex;
+  gap: calc(100vh / 101.25);
+  flex-direction: column;
+
+  min-width: 41.1rem;
+`;
+
+const title = css`
+  color: ${colors.gray900};
+  ${fonts.desktop_title_semi_28};
+`;
+
+const designerContainer = css`
+  display: flex;
+  gap: calc(100vh / 101.25);
+  align-items: center;
+`;
+
+const designerName = css`
+  color: ${colors.gray900};
+  ${fonts.desktop_body_reg_20};
+`;
+
+const workDescription = css`
+  display: flex;
+  gap: calc(100vh / 33.75);
+  justify-content: center;
+  flex-direction: column;
+  flex-grow: 1;
+`;
+
+const krDesc = css`
+  color: ${colors.gray900};
+  ${fonts.desktop_body_reg_16};
+
+  white-space: pre-wrap;
+`;
+
+const engDesc = css`
+  color: ${colors.gray500};
+  ${fonts.desktop_body_lig_16};
+
+  white-space: pre-wrap;
+`;
+
+const workImages = css`
+  padding: 0 calc(100% / 14.4);
+`;
+
+const workImg = css`
+  width: 100%;
+
+  object-fit: cover;
+`;
+
+const designedByContainer = css`
+  display: flex;
+  gap: calc(100vh / 20.25);
+  flex-direction: column;
+
+  margin: calc(100vh / 8.1) 0 calc(100vh / 5.79) calc(100% / 24);
+`;
+
+const designedByTitle = css`
+  color: ${colors.gray900};
+  ${fonts.desktop_title_semi_28};
+`;
+
+const totalDesigners = css`
+  display: flex;
+  gap: 3.2rem;
+  align-items: center;
+`;
+
+const designerInfoContainer = css`
+  display: flex;
+  gap: 1.6rem;
+  justify-content: center;
+  flex-direction: column;
+`;
+
+const designerInfo = css`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+`;
+
+const designerKrName = css`
+  margin-bottom: 0.4rem;
+
+  color: ${colors.gray900};
+  ${fonts.desktop_body_semi_20};
+`;
+
+const designerEngName = css`
+  margin-bottom: 0.8rem;
+
+  color: ${colors.gray900};
+  ${fonts.desktop_body_reg_18};
+`;
+
+const designerEmail = css`
+  color: ${colors.gray500};
+  ${fonts.desktop_body_reg_16};
+`;
+
+const designersWork = css`
+  width: 30.6rem;
+  aspect-ratio: 1/1;
+`;

--- a/src/desktop/WorkDetail/pages/WorkDetailPage.tsx
+++ b/src/desktop/WorkDetail/pages/WorkDetailPage.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { useEffect } from 'react';
 import PageLayout from '../../Common/PageLayout';
 import Designers from '../components/Designers';
 import DetailImages from '../components/DetailImages';
@@ -89,6 +90,10 @@ const DUMMY = {
 const WorkDetailPage = () => {
   const { workTitle, workBody, workEngBody, thumbnail, images, designers } =
     DUMMY;
+
+  useEffect(() => {
+    window.scrollTo({ top: 0 });
+  }, []);
 
   return (
     <PageLayout>

--- a/src/desktop/WorkDetail/pages/WorkDetailPage.tsx
+++ b/src/desktop/WorkDetail/pages/WorkDetailPage.tsx
@@ -167,7 +167,7 @@ const WorkDetailPage = () => {
                       isStaticImg && handleHoverImg(workTitle, name)
                     }
                     onMouseLeave={handleLeaveImg}
-                  ></img>
+                  />
 
                   {isHoveredImg && (
                     <div css={hoveredInfo}>
@@ -277,16 +277,20 @@ const designedByTitle = css`
 
 const totalDesigners = css`
   display: flex;
-  gap: 3.2rem;
+  gap: calc(100% / 45);
   align-items: center;
 `;
 
 const designerInfoContainer = css`
   display: flex;
-  gap: 1.6rem;
+  gap: calc(100vh / 50.6);
   justify-content: center;
   flex-direction: column;
   position: relative;
+
+  min-width: 30.6rem;
+
+  width: calc(100% / 4.7);
 `;
 
 const designerInfo = css`
@@ -296,14 +300,14 @@ const designerInfo = css`
 `;
 
 const designerKrName = css`
-  margin-bottom: 0.4rem;
+  margin-bottom: calc(100vh / 202.5);
 
   color: ${colors.gray900};
   ${fonts.desktop_body_semi_20};
 `;
 
 const designerEngName = css`
-  margin-bottom: 0.8rem;
+  margin-bottom: calc(100vh / 101.25);
 
   color: ${colors.gray900};
   ${fonts.desktop_body_reg_18};
@@ -315,8 +319,12 @@ const designerEmail = css`
 `;
 
 const designersWork = (isHoveredImg: boolean) => css`
-  width: 30.6rem;
-  aspect-ratio: 1/1;
+  min-height: 30.6rem;
+
+  width: 100%;
+  aspect-ratio: 1 / 1;
+
+  object-fit: cover;
 
   ${isHoveredImg &&
   css`
@@ -326,7 +334,7 @@ const designersWork = (isHoveredImg: boolean) => css`
 
 const hoveredInfo = css`
   display: flex;
-  gap: 0.4rem;
+  gap: calc(100vh / 202.5);
   flex-direction: column;
   position: absolute;
   bottom: 1.6rem;

--- a/src/desktop/WorkDetail/pages/WorkDetailPage.tsx
+++ b/src/desktop/WorkDetail/pages/WorkDetailPage.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/react';
-import { useState } from 'react';
-import { colors, fonts } from '../../../styles/theme';
 import PageLayout from '../../Common/PageLayout';
+import Designers from '../components/Designers';
+import DetailImages from '../components/DetailImages';
+import Details from '../components/Details';
 
 const DUMMY = {
   workTitle: '디지털 일러스트',
@@ -89,97 +90,18 @@ const WorkDetailPage = () => {
   const { workTitle, workBody, workEngBody, thumbnail, images, designers } =
     DUMMY;
 
-  const [hoveredImg, setHoveredImg] = useState({
-    hoveredTitle: '',
-    hoveredName: '',
-  });
-
-  const { hoveredName, hoveredTitle } = hoveredImg;
-
-  const handleHoverImg = (workTitle: string, name: string) => {
-    setHoveredImg({
-      hoveredTitle: workTitle,
-      hoveredName: name,
-    });
-  };
-
-  const handleLeaveImg = () => {
-    setHoveredImg({
-      hoveredTitle: '',
-      hoveredName: '',
-    });
-  };
-
   return (
     <PageLayout>
       <section css={workDetailContainer}>
         <img src={thumbnail} css={workThumbnail} />
-        <article css={workDetail}>
-          <div css={workInfo}>
-            <p css={title}>{workTitle}</p>
-            <div css={designerContainer}>
-              {designers.map((designer) => {
-                const { name } = designer;
-                return (
-                  <p key={name} css={designerName}>
-                    {name}
-                  </p>
-                );
-              })}
-            </div>
-          </div>
-          <div css={workDescription}>
-            <p css={krDesc}>{workBody}</p>
-            <p css={engDesc}>{workEngBody}</p>
-          </div>
-        </article>
-
-        <article css={workImages}>
-          {images.map((image) => {
-            const { sort, imgPath } = image;
-            return <img key={sort} src={imgPath} css={workImg} />;
-          })}
-        </article>
-
-        <article css={designedByContainer}>
-          <p css={designedByTitle}>Designed by</p>
-          <div css={totalDesigners}>
-            {designers.map((designer) => {
-              const { name, engName, email, workTitle, studioNm, images } =
-                designer;
-              const { imgPath, fileFormat } =
-                images.length > 1 ? images[1] : images[0];
-              const isStaticImg = fileFormat !== 'gif';
-              const isHoveredImg =
-                hoveredTitle === workTitle && hoveredName === name;
-
-              return (
-                <article key={name} css={designerInfoContainer}>
-                  <div css={designerInfo}>
-                    <p css={designerKrName}>{name}</p>
-                    <p css={designerEngName}>{engName}</p>
-                    <p css={designerEmail}>{email}</p>
-                  </div>
-                  <img
-                    src={imgPath}
-                    css={designersWork(isHoveredImg)}
-                    onMouseEnter={() =>
-                      isStaticImg && handleHoverImg(workTitle, name)
-                    }
-                    onMouseLeave={handleLeaveImg}
-                  />
-
-                  {isHoveredImg && (
-                    <div css={hoveredInfo}>
-                      <p css={hoveredWorkTitle}>{workTitle}</p>
-                      <p css={hoveredStudioNm}>{studioNm}</p>
-                    </div>
-                  )}
-                </article>
-              );
-            })}
-          </div>
-        </article>
+        <Details
+          workTitle={workTitle}
+          designers={designers}
+          workBody={workBody}
+          workEngBody={workEngBody}
+        />
+        <DetailImages images={images} />
+        <Designers designers={designers} />
       </section>
     </PageLayout>
   );
@@ -196,157 +118,4 @@ const workDetailContainer = css`
 const workThumbnail = css`
   width: 100%;
   height: calc(100vh / 1.65);
-`;
-
-const workDetail = css`
-  display: flex;
-  gap: calc(100% / 26.19);
-  justify-content: center;
-
-  margin: calc(100vh / 10.125) calc(100% / 14.4) calc(100vh / 7.79);
-`;
-
-const workInfo = css`
-  display: flex;
-  gap: calc(100vh / 101.25);
-  flex-direction: column;
-
-  min-width: 41.1rem;
-`;
-
-const title = css`
-  color: ${colors.gray900};
-  ${fonts.desktop_title_semi_28};
-`;
-
-const designerContainer = css`
-  display: flex;
-  gap: calc(100vh / 101.25);
-  align-items: center;
-`;
-
-const designerName = css`
-  color: ${colors.gray900};
-  ${fonts.desktop_body_reg_20};
-`;
-
-const workDescription = css`
-  display: flex;
-  gap: calc(100vh / 33.75);
-  justify-content: center;
-  flex-direction: column;
-  flex-grow: 1;
-`;
-
-const krDesc = css`
-  color: ${colors.gray900};
-  ${fonts.desktop_body_reg_16};
-
-  white-space: pre-wrap;
-`;
-
-const engDesc = css`
-  color: ${colors.gray500};
-  ${fonts.desktop_body_lig_16};
-
-  white-space: pre-wrap;
-`;
-
-const workImages = css`
-  padding: 0 calc(100% / 14.4);
-`;
-
-const workImg = css`
-  width: 100%;
-
-  object-fit: cover;
-`;
-
-const designedByContainer = css`
-  display: flex;
-  gap: calc(100vh / 20.25);
-  flex-direction: column;
-
-  margin: calc(100vh / 8.1) 0 calc(100vh / 5.79) calc(100% / 24);
-`;
-
-const designedByTitle = css`
-  color: ${colors.gray900};
-  ${fonts.desktop_title_semi_28};
-`;
-
-const totalDesigners = css`
-  display: flex;
-  gap: calc(100% / 45);
-  align-items: center;
-`;
-
-const designerInfoContainer = css`
-  display: flex;
-  gap: calc(100vh / 50.6);
-  justify-content: center;
-  flex-direction: column;
-  position: relative;
-
-  min-width: 30.6rem;
-
-  width: calc(100% / 4.7);
-`;
-
-const designerInfo = css`
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-`;
-
-const designerKrName = css`
-  margin-bottom: calc(100vh / 202.5);
-
-  color: ${colors.gray900};
-  ${fonts.desktop_body_semi_20};
-`;
-
-const designerEngName = css`
-  margin-bottom: calc(100vh / 101.25);
-
-  color: ${colors.gray900};
-  ${fonts.desktop_body_reg_18};
-`;
-
-const designerEmail = css`
-  color: ${colors.gray500};
-  ${fonts.desktop_body_reg_16};
-`;
-
-const designersWork = (isHoveredImg: boolean) => css`
-  min-height: 30.6rem;
-
-  width: 100%;
-  aspect-ratio: 1 / 1;
-
-  object-fit: cover;
-
-  ${isHoveredImg &&
-  css`
-    filter: brightness(0.5);
-  `}
-`;
-
-const hoveredInfo = css`
-  display: flex;
-  gap: calc(100vh / 202.5);
-  flex-direction: column;
-  position: absolute;
-  bottom: 1.6rem;
-  left: 1.6rem;
-`;
-
-const hoveredWorkTitle = css`
-  color: ${colors.white};
-  ${fonts.desktop_body_semi_20};
-`;
-
-const hoveredStudioNm = css`
-  color: ${colors.white};
-  ${fonts.desktop_body_reg_18};
 `;

--- a/src/desktop/WorkDetail/types/workDetailTypes.ts
+++ b/src/desktop/WorkDetail/types/workDetailTypes.ts
@@ -1,0 +1,24 @@
+export interface DetailsProps {
+    workTitle: string;
+    designers: Array<{ name: string }>;
+    workBody: string;
+    workEngBody: string;
+  }
+  
+export interface DetailImagesProps {
+    images: Array<{
+      sort: number;
+      imgPath: string;
+    }>;
+  }
+
+export interface DesignersProps {
+    designers: Array<{
+      name: string;
+      engName: string;
+      email: string;
+      workTitle: string;
+      studioNm: string;
+      images: Array<{ imgPath: string; fileFormat: string }>;
+    }>;
+  }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #9 

## ✅ 작업 내용

- [x] 작업 상세 뷰 퍼블리싱
- [x] 작업 상세 뷰 렌더링 시, 스크롤 위치를 최상단으로 고정

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/a47aad9a-e71a-4ff3-abca-1a608dbb925c


## 📌 이슈 사항
### 1️⃣ 작업 상세 뷰 렌더링 시, 스크롤 위치를 최상단으로 고정
- 리액트는 이전 페이지 스크롤 위치를 기억하기 때문에, 다음 페이지로 넘어갈 경우 이전 페이지의 스크롤 위치와 동일한 위치의 페이지가 렌더링됩니다 ! 뷰가 새로 렌더링되었는데 스크롤이 최상단에 위치되어 있지 않는다면, 서비스 플로우가 어색하게 느껴질 것이라고 생각해서 해당 페이지 렌더링 시 스크롤이 최상단에 가도록 구현했어요.

```typescript
  useEffect(() => {
    window.scrollTo({ top: 0 });
  }, []);
```

<br />

### 2️⃣ 이미지 호버 이벤트
- 디자이너가 참여한 작품의 이미지가 호버될 경우, 해당 작품의 정보가 뜨도록 구현했어요.
- 다만, 디자이너분들의 요청대로 이미지가 gif일 경우 호버 이벤트 없이 이미지가 계속 재생되도록 구현했습니다.

```typescript
 const isStaticImg = fileFormat !== 'gif';
 const isHoveredImg = hoveredTitle === workTitle && hoveredName === name;

  return (
    <article key={name} css={designerInfoContainer}>
       ...
        <img
           src={imgPath}
           css={designersWork(isHoveredImg)}
           onMouseEnter={() =>
              isStaticImg && handleHoverImg(workTitle, name)
            }
           onMouseLeave={handleLeaveImg}
         />
        ...
```