### PR TITLE
[ Mobile / Tablet ] 스크롤 애니메이션 삭제

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import MobileRouter from './MobileRouter';
 import { GlobalStyles } from './styles/GlobalStyles';
 import TabletRouter from './TabletRouter';
 
-function App() {
+const App = () => {
   const [queryClient] = useState(() => new QueryClient());
 
   const width = useRef(window.innerWidth);
@@ -38,6 +38,6 @@ function App() {
       {renderRouter()}
     </QueryClientProvider>
   );
-}
+};
 
 export default App;

--- a/src/mobile/Common/PageLayout.tsx
+++ b/src/mobile/Common/PageLayout.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { useEffect } from 'react';
 import Footer from './Footer';
 import Header from './Header';
 
@@ -7,6 +8,10 @@ interface PageLayoutProps {
 }
 
 const PageLayout = (props: PageLayoutProps) => {
+  useEffect(() => {
+    scrollTo({ top: 0, left: 0, behavior: 'instant' });
+  }, []);
+
   const { children } = props;
 
   return (

--- a/src/mobile/Designer/components/DesignerInfo.tsx
+++ b/src/mobile/Designer/components/DesignerInfo.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { colors, fonts } from '../../../styles/theme';
 import { DESIGNER_DETAIL } from '../../constants/DESIGNER_DETAIL';
 
-function DesignerInfo() {
+const DesignerInfo = () => {
   const { name, engName, major, email, instagram, behance } =
     DESIGNER_DETAIL.data;
   return (
@@ -36,7 +36,7 @@ function DesignerInfo() {
       </ul>
     </section>
   );
-}
+};
 
 export default DesignerInfo;
 

--- a/src/mobile/Designer/components/Works.tsx
+++ b/src/mobile/Designer/components/Works.tsx
@@ -4,7 +4,7 @@ import { colors, fonts } from '../../../styles/theme';
 import { updateStudioUrl } from '../../../utils/updateStudioUrl';
 import { DESIGNER_DETAIL } from '../../constants/DESIGNER_DETAIL';
 
-function Works() {
+const Works = () => {
   const workList = DESIGNER_DETAIL.data.works;
 
   return (
@@ -30,7 +30,7 @@ function Works() {
       })}
     </section>
   );
-}
+};
 
 export default Works;
 

--- a/src/mobile/Designer/page/DesignerPage.tsx
+++ b/src/mobile/Designer/page/DesignerPage.tsx
@@ -1,15 +1,10 @@
 import { css } from '@emotion/react';
-import { useEffect } from 'react';
 import { ImgBg3Mobile } from '../../assets/image';
 import PageLayout from '../../Common/PageLayout';
 import DesignerInfo from '../components/DesignerInfo';
 import Works from '../components/Works';
 
 const DesignerPage = () => {
-  useEffect(() => {
-    scrollTo(0, 0);
-  }, []);
-
   return (
     <PageLayout>
       <section css={designerContainer(ImgBg3Mobile)}>

--- a/src/mobile/Designers/components/DesignerList.tsx
+++ b/src/mobile/Designers/components/DesignerList.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { Link } from 'react-router-dom';
 import { DESIGNERS } from '../../constants/DESIGNERS';
 
-function DesignerList() {
+const DesignerList = () => {
   return (
     <ul css={listContainter}>
       {DESIGNERS.map((designer) => {
@@ -17,7 +17,7 @@ function DesignerList() {
       })}
     </ul>
   );
-}
+};
 
 export default DesignerList;
 

--- a/src/mobile/Designers/page/DesignersPage.tsx
+++ b/src/mobile/Designers/page/DesignersPage.tsx
@@ -1,15 +1,10 @@
 import { css } from '@emotion/react';
-import { useEffect } from 'react';
 import { colors, fonts } from '../../../styles/theme';
 import PageLayout from '../../Common/PageLayout';
 import { ImgBg3Mobile } from '../../assets/image';
 import DesignerList from '../components/DesignerList';
 
 const DesignersPage = () => {
-  useEffect(() => {
-    scrollTo(0, 0);
-  }, []);
-
   return (
     <PageLayout>
       <div css={designersCss(ImgBg3Mobile)}>

--- a/src/mobile/Display/page/DisplayPage.tsx
+++ b/src/mobile/Display/page/DisplayPage.tsx
@@ -1,15 +1,10 @@
 import { css } from '@emotion/react';
-import { useEffect } from 'react';
 import { colors, fonts } from '../../../styles/theme';
 import { ImgBg2Mobile } from '../../assets/image';
 import PageLayout from '../../Common/PageLayout';
 import { DISPLAY } from '../../constants/DISPLAY';
 
 const DisplayPage = () => {
-  useEffect(() => {
-    scrollTo(0, 0);
-  }, []);
-
   const StudioImages1 =
     DISPLAY.find((item) => item.displayId === 1)?.images || [];
 

--- a/src/mobile/Studio/components/StudioInfo.tsx
+++ b/src/mobile/Studio/components/StudioInfo.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { colors, fonts } from '../../../styles/theme';
 import { studioInfoProps } from '../types/studioType';
 
-function StudioInfoMobile(studioInfo: studioInfoProps) {
+const StudioInfoMobile = (studioInfo: studioInfoProps) => {
   const { studio, advisor, description, mobileImgSrc } = studioInfo.info;
 
   return (
@@ -17,7 +17,7 @@ function StudioInfoMobile(studioInfo: studioInfoProps) {
       <p css={descriptionCss}>{description}</p>
     </section>
   );
-}
+};
 
 export default StudioInfoMobile;
 

--- a/src/mobile/Studio/components/WorkList.tsx
+++ b/src/mobile/Studio/components/WorkList.tsx
@@ -4,7 +4,7 @@ import { colors, fonts } from '../../../styles/theme';
 import { Link } from 'react-router-dom';
 import { DESIGNER_TOTAL_WORKS } from '../../constants/WORKS';
 
-function WorkList() {
+const WorkList = () => {
   const workList = DESIGNER_TOTAL_WORKS.data.works;
 
   return (
@@ -35,7 +35,7 @@ function WorkList() {
       })}
     </ul>
   );
-}
+};
 
 export default WorkList;
 

--- a/src/mobile/Studio/page/StudioPage.tsx
+++ b/src/mobile/Studio/page/StudioPage.tsx
@@ -3,16 +3,11 @@ import { useLocation } from 'react-router-dom';
 import { ImgBg2Mobile } from '../../assets/image';
 import PageLayout from '../../Common/PageLayout';
 
-import { useEffect } from 'react';
 import StudioInfoMobile from '../components/StudioInfo';
 import WorkList from '../components/WorkList';
 
 const StudioPage = () => {
   const location = useLocation();
-
-  useEffect(() => {
-    scrollTo(0, 0);
-  }, []);
 
   return (
     <PageLayout>

--- a/src/mobile/WorkDetail/components/DesignerList.tsx
+++ b/src/mobile/WorkDetail/components/DesignerList.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { colors, fonts } from '../../../styles/theme';
 import { WORK_DETAIL_DESIGNER } from '../../constants/WORK_DETAIL_DESIGNER';
 
-function DesignerList() {
+const DesignerList = () => {
   return (
     <div css={designerListContainer}>
       <h1 css={title}>Designed By</h1>
@@ -29,7 +29,7 @@ function DesignerList() {
       </ul>
     </div>
   );
-}
+};
 
 export default DesignerList;
 

--- a/src/mobile/WorkDetail/components/WorkImage.tsx
+++ b/src/mobile/WorkDetail/components/WorkImage.tsx
@@ -1,9 +1,7 @@
 import { css } from '@emotion/react';
 import { WorkImageProps } from '../types/WorkDetailType';
 
-function WorkImage(props: WorkImageProps) {
-  const { images } = props;
-
+const WorkImage = ({ images }: WorkImageProps) => {
   return (
     <div css={imageSection}>
       {images.map((item) => {
@@ -13,7 +11,7 @@ function WorkImage(props: WorkImageProps) {
       })}
     </div>
   );
-}
+};
 
 export default WorkImage;
 

--- a/src/mobile/WorkDetail/components/WorkInfo.tsx
+++ b/src/mobile/WorkDetail/components/WorkInfo.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { colors, fonts } from '../../../styles/theme';
 import { WorkInfoProps } from '../types/WorkDetailType';
 
-function WorkInfo(props: WorkInfoProps) {
+const WorkInfo = (props: WorkInfoProps) => {
   const { title, description, engDescription, designers } = props;
 
   const designerList = designers.map((designer) => designer.name).join(' ');
@@ -19,7 +19,7 @@ function WorkInfo(props: WorkInfoProps) {
       </div>
     </div>
   );
-}
+};
 
 export default WorkInfo;
 

--- a/src/mobile/Works/page/WorksPage.tsx
+++ b/src/mobile/Works/page/WorksPage.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { STUDIO_DETAILS } from '../../../constants/studioDetail';
 import { colors, fonts } from '../../../styles/theme';
@@ -7,10 +6,6 @@ import PageLayout from '../../Common/PageLayout';
 import { ImgBg2Mobile } from '../../assets/image';
 
 const WorksPage = () => {
-  useEffect(() => {
-    scrollTo(0, 0);
-  }, []);
-
   return (
     <PageLayout>
       <section css={worksContainer(ImgBg2Mobile)}>

--- a/src/tablet/Common/PageLayout.tsx
+++ b/src/tablet/Common/PageLayout.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 
+import { useEffect } from 'react';
 import Footer from '../../mobile/Common/Footer';
 import Header from './Header';
 
@@ -9,6 +10,10 @@ interface PageLayoutProps {
 
 const PageLayout = (props: PageLayoutProps) => {
   const { children } = props;
+
+  useEffect(() => {
+    scrollTo({ top: 0, left: 0, behavior: 'instant' });
+  }, []);
 
   return (
     <div css={pageLayoutCss}>

--- a/src/tablet/Designer/page/DesignerPage.tsx
+++ b/src/tablet/Designer/page/DesignerPage.tsx
@@ -1,15 +1,10 @@
 import { css } from '@emotion/react';
-import { useEffect } from 'react';
 import DesignerInfo from '../../../mobile/Designer/components/DesignerInfo';
 import Works from '../../../mobile/Designer/components/Works';
 import { ImgBg3Tablet } from '../../assets/image';
 import PageLayout from '../../Common/PageLayout';
 
 const DesignerPage = () => {
-  useEffect(() => {
-    scrollTo(0, 0);
-  }, []);
-
   return (
     <PageLayout>
       <section css={designerContainer(ImgBg3Tablet)}>

--- a/src/tablet/Designers/page/DesignersPage.tsx
+++ b/src/tablet/Designers/page/DesignersPage.tsx
@@ -1,15 +1,10 @@
 import { css } from '@emotion/react';
-import { useEffect } from 'react';
 import DesignerList from '../../../mobile/Designers/components/DesignerList';
 import { colors, fonts } from '../../../styles/theme';
 import PageLayout from '../../Common/PageLayout';
 import { ImgBg3Tablet } from '../../assets/image';
 
 const DesignersPage = () => {
-  useEffect(() => {
-    scrollTo(0, 0);
-  }, []);
-
   return (
     <PageLayout>
       <div css={designersCss(ImgBg3Tablet)}>

--- a/src/tablet/Display/page/DisplayPage.tsx
+++ b/src/tablet/Display/page/DisplayPage.tsx
@@ -1,15 +1,10 @@
 import { css } from '@emotion/react';
-import { useEffect } from 'react';
 import { DISPLAY } from '../../../mobile/constants/DISPLAY';
 import { colors, fonts } from '../../../styles/theme';
 import PageLayout from '../../Common/PageLayout';
 import { ImgBg2Tablet } from '../../assets/image';
 
 const DisplayPage = () => {
-  useEffect(() => {
-    scrollTo(0, 0);
-  }, []);
-
   const StudioImages1 =
     DISPLAY.find((item) => item.displayId === 1)?.images || [];
 

--- a/src/tablet/Studio/page/StudioPage.tsx
+++ b/src/tablet/Studio/page/StudioPage.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { useLocation } from 'react-router-dom';
 
-import { useEffect } from 'react';
 import StudioInfoMobile from '../../../mobile/Studio/components/StudioInfo';
 import WorkList from '../../../mobile/Studio/components/WorkList';
 import { ImgBg2Tablet } from '../../assets/image';
@@ -9,10 +8,6 @@ import PageLayout from '../../Common/PageLayout';
 
 const StudioPage = () => {
   const location = useLocation();
-
-  useEffect(() => {
-    scrollTo(0, 0);
-  }, []);
 
   return (
     <PageLayout>

--- a/src/tablet/WorkDetail/components/DesignerList.tsx
+++ b/src/tablet/WorkDetail/components/DesignerList.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { WORK_DETAIL_DESIGNER } from '../../../mobile/constants/WORK_DETAIL_DESIGNER';
 import { colors, fonts } from '../../../styles/theme';
 
-function DesignerList() {
+const DesignerList = () => {
   return (
     <div css={designerListContainer}>
       <h1 css={title}>Designed By</h1>
@@ -29,7 +29,7 @@ function DesignerList() {
       </ul>
     </div>
   );
-}
+};
 
 export default DesignerList;
 

--- a/src/tablet/WorkDetail/components/WorkImage.tsx
+++ b/src/tablet/WorkDetail/components/WorkImage.tsx
@@ -1,9 +1,7 @@
 import { css } from '@emotion/react';
 import { WorkImageProps } from '../../../mobile/WorkDetail/types/WorkDetailType';
 
-function WorkImage(props: WorkImageProps) {
-  const { images } = props;
-
+const WorkImage = ({ images }: WorkImageProps) => {
   return (
     <div css={imageSection}>
       {images.map((item) => {
@@ -13,7 +11,7 @@ function WorkImage(props: WorkImageProps) {
       })}
     </div>
   );
-}
+};
 
 export default WorkImage;
 

--- a/src/tablet/WorkDetail/components/WorkInfo.tsx
+++ b/src/tablet/WorkDetail/components/WorkInfo.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { WorkInfoProps } from '../../../mobile/WorkDetail/types/WorkDetailType';
 import { colors, fonts } from '../../../styles/theme';
 
-function WorkInfo(props: WorkInfoProps) {
+const WorkInfo = (props: WorkInfoProps) => {
   const { title, description, engDescription, designers } = props;
 
   const designerList = designers.map((designer) => designer.name).join(' ');
@@ -19,7 +19,7 @@ function WorkInfo(props: WorkInfoProps) {
       </div>
     </div>
   );
-}
+};
 
 export default WorkInfo;
 

--- a/src/tablet/WorkDetail/page/WorkDetailPage.tsx
+++ b/src/tablet/WorkDetail/page/WorkDetailPage.tsx
@@ -1,17 +1,12 @@
 import { css } from '@emotion/react';
 import PageLayout from '../../Common/PageLayout';
 
-import { useEffect } from 'react';
 import { WORK_DETAIL } from '../../../mobile/constants/WORK_DETAIL';
 import DesignerList from '../components/DesignerList';
 import WorkImage from '../components/WorkImage';
 import WorkInfo from '../components/WorkInfo';
 
 const WorkDetailPage = () => {
-  useEffect(() => {
-    scrollTo(0, 0);
-  }, []);
-
   const { workTitle, workBody, workEngBody, thumbnail, images, designers } =
     WORK_DETAIL;
 

--- a/src/tablet/Works/page/WorksPage.tsx
+++ b/src/tablet/Works/page/WorksPage.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { STUDIO_DETAILS } from '../../../constants/studioDetail';
 import { colors, fonts } from '../../../styles/theme';
@@ -7,10 +6,6 @@ import PageLayout from '../../Common/PageLayout';
 import { ImgBg2Tablet } from '../../assets/image';
 
 const WorksPage = () => {
-  useEffect(() => {
-    scrollTo(0, 0);
-  }, []);
-
   return (
     <PageLayout>
       <section css={worksContainer(ImgBg2Tablet)}>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #51 
## ✅ 작업 내용

- [x] 모바일 애니메이션 제거
- [x] 태블릿 애니메이션 제거

## 📌 이슈 사항
각 url의 page.tsx마다 scrollTo(0,0)을 주고 있었는데, 한번에 PageLayout.tsx 컴포넌트에 scrollTo를 넣어주었습니다..! (데스크탑에서도 필요한 기능이라면 App.tsx에 넣어도 될 듯 합니다.....!)
