### PR TITLE
[ QA ] 3차

### DIFF
--- a/src/desktop/Designer/pages/DesignerPage.tsx
+++ b/src/desktop/Designer/pages/DesignerPage.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import useGetDesignerDetail from '../../../libs/hooks/useGetDesignerDetail';
 import { colors, fonts } from '../../../styles/theme';
 import { renderEngName } from '../../../utils/renderEngName';
@@ -9,8 +9,13 @@ import DesignerContact from '../components/DesignerContact';
 import DesignerWorks from '../components/DesignerWorks';
 
 const DesignerPage = () => {
-  const { designerId } = useLocation().state;
-  const { designerDetail, isLoading } = useGetDesignerDetail(designerId);
+  const designerName = useParams().name;
+  const designerId =
+    designerName?.split('-')[designerName?.split('-').length - 1];
+  if (!designerId) return;
+  const { designerDetail, isLoading } = useGetDesignerDetail(
+    parseInt(designerId),
+  );
   const { data } = !isLoading && designerDetail;
 
   const { name, engName, major, email, instagram, behance, works } =

--- a/src/desktop/Designers/components/TotalDesigners.tsx
+++ b/src/desktop/Designers/components/TotalDesigners.tsx
@@ -11,7 +11,7 @@ const TotalDesigners = () => {
         const url = engName.split(' ').join('-');
 
         return (
-          <Link key={designerId} to={url} state={{ designerId: designerId }}>
+          <Link key={designerId} to={`${url}-${designerId}`}>
             <img src={imgPath} css={designerImg} />
           </Link>
         );

--- a/src/desktop/Studio/components/TotalWorks.tsx
+++ b/src/desktop/Studio/components/TotalWorks.tsx
@@ -60,7 +60,9 @@ const TotalWorks = ({ id }: TotalWorksProps) => {
             >
               <Link to={`${url}-${workId}`}>
                 <img src={isHoveredGif ? hoveredSrc : imgPath} css={workImg} />
-                <p css={title(isHoveredImg)}>{workTitle}</p>
+                <p css={title(isHoveredImg)}>
+                  {workTitle.replace(/\\n/g, '\n')}
+                </p>
                 <div css={designerNameContainer}>
                   {designers.map((designer, idx) => {
                     const { name } = designer;
@@ -109,7 +111,9 @@ const title = (isHoveredImg: boolean) => css`
   margin-bottom: calc(100vh / 202.5);
 
   color: ${isHoveredImg ? colors.pink300 : colors.gray900};
+
   ${fonts.desktop_body_semi_20};
+  white-space: pre-wrap;
 `;
 
 const designerNameContainer = css`

--- a/src/desktop/WorkDetail/components/Designers.tsx
+++ b/src/desktop/WorkDetail/components/Designers.tsx
@@ -39,7 +39,6 @@ const Designers = ({ designers, currentWorkId }: DesignersProps) => {
               ? works.filter((work) => work.workId !== currentWorkId)[0]
               : works[0];
           const { imgPath } = images[0];
-          console.log(images);
           const isHoveredImg =
             hoveredTitle === workTitle && hoveredName === name;
           const studioUrl = updateStudioUrl(studioNm);

--- a/src/desktop/WorkDetail/components/Details.tsx
+++ b/src/desktop/WorkDetail/components/Details.tsx
@@ -24,8 +24,8 @@ const Details = ({
         </div>
       </div>
       <div css={workDescription}>
-        <p css={krDesc}>{workBody}</p>
-        <p css={engDesc}>{workEngBody}</p>
+        <p css={krDesc}>{workBody.replace(/\\n/g, '\n')}</p>
+        <p css={engDesc}>{workEngBody.replace(/\\n/g, '\n')}</p>
       </div>
     </article>
   );

--- a/src/desktop/WorkDetail/components/Details.tsx
+++ b/src/desktop/WorkDetail/components/Details.tsx
@@ -11,12 +11,12 @@ const Details = ({
   return (
     <article css={workDetail}>
       <div css={workInfo}>
-        <p css={title}>{workTitle}</p>
+        <p css={title}>{workTitle.replace(/\\n/g, '\n')}</p>
         <div css={designerContainer}>
-          {designers.map((designer) => {
+          {designers.map((designer, idx) => {
             const { name } = designer;
             return (
-              <p key={name} css={designerName}>
+              <p key={name + idx} css={designerName}>
                 {name}
               </p>
             );
@@ -52,6 +52,8 @@ const workInfo = css`
 const title = css`
   color: ${colors.gray900};
   ${fonts.desktop_title_semi_28};
+
+  white-space: pre-wrap;
 `;
 
 const designerContainer = css`

--- a/src/mobile/Designer/page/DesignerPage.tsx
+++ b/src/mobile/Designer/page/DesignerPage.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import useGetDesignerDetail from '../../../libs/hooks/useGetDesignerDetail';
 import { ImgBg3Mobile } from '../../assets/image';
 import PageLayout from '../../Common/PageLayout';
@@ -7,8 +7,13 @@ import DesignerInfo from '../components/DesignerInfo';
 import Works from '../components/Works';
 
 const DesignerPage = () => {
-  const { designerId } = useLocation().state;
-  const { designerDetail, isLoading } = useGetDesignerDetail(designerId);
+  const designerName = useParams().name;
+  const designerId =
+    designerName?.split('-')[designerName?.split('-').length - 1];
+  if (!designerId) return;
+  const { designerDetail, isLoading } = useGetDesignerDetail(
+    parseInt(designerId),
+  );
   const { data } = !isLoading && designerDetail;
 
   const { name, engName, major, email, instagram, behance, works } =

--- a/src/mobile/Designers/components/DesignerList.tsx
+++ b/src/mobile/Designers/components/DesignerList.tsx
@@ -16,12 +16,7 @@ const DesignerList = () => {
         const url = engName.trim().split(' ').join('-');
 
         return (
-          <Link
-            to={url}
-            key={designerId}
-            css={imgCss}
-            state={{ designerId: designerId }}
-          >
+          <Link to={`${url}-${designerId}`} key={designerId} css={imgCss}>
             <img src={imgPath} alt={`${engName}의 디자이너 이미지`} />
           </Link>
         );

--- a/src/mobile/Studio/components/WorkList.tsx
+++ b/src/mobile/Studio/components/WorkList.tsx
@@ -36,7 +36,7 @@ const WorkList = ({ id }: WorkListProps) => {
                 />
               </div>
               <div css={textCss}>
-                <h1 css={title}>{workTitle}</h1>
+                <h1 css={title}>{workTitle.replace(/\\n/g, '\n')}</h1>
                 <h2 css={name}>{designerList}</h2>
               </div>
             </Link>
@@ -127,11 +127,13 @@ const title = css`
   /* 모바일 */
   @media (width < 768px) {
     ${fonts.mobile_body_semi_14};
+    white-space: pre-wrap;
   }
 
   /* 태블릿 */
   @media (768px <= width < 1440px) {
     ${fonts.tablet_body_semi_16};
+    white-space: pre-wrap;
   }
 `;
 

--- a/src/mobile/WorkDetail/components/WorkInfo.tsx
+++ b/src/mobile/WorkDetail/components/WorkInfo.tsx
@@ -40,6 +40,7 @@ const mainCss = css`
     margin-bottom: 0.2rem;
 
     ${fonts.mobile_title_semi_20};
+    white-space: pre-wrap;
   }
 
   p:nth-of-type(1) {

--- a/src/mobile/WorkDetail/page/WorkDetailPage.tsx
+++ b/src/mobile/WorkDetail/page/WorkDetailPage.tsx
@@ -33,8 +33,8 @@ const WorkDetailPage = () => {
         />
         <WorkInfo
           title={workTitle}
-          description={workBody}
-          engDescription={workEngBody}
+          description={workBody.replace(/\\n/g, '\n')}
+          engDescription={workEngBody.replace(/\\n/g, '\n')}
           designers={designers}
         />
         <WorkImage images={images} />

--- a/src/mobile/WorkDetail/page/WorkDetailPage.tsx
+++ b/src/mobile/WorkDetail/page/WorkDetailPage.tsx
@@ -19,30 +19,34 @@ const WorkDetailPage = () => {
     parseInt(currentWorkId),
   );
 
+  const isLoading = isWorkDetailLoading || isWorkDesignersLoading;
+
   const { workTitle, workBody, workEngBody, workBanner, images } =
     !isWorkDetailLoading && workDetail.data;
   const designers = !isWorkDesignersLoading && workDesigners.data;
 
   return (
     <PageLayout>
-      <section css={WorkDetailContainer}>
-        <img
-          src={workBanner}
-          alt={`${workTitle}의 썸네일`}
-          css={thumbnailImg}
-        />
-        <WorkInfo
-          title={workTitle}
-          description={workBody.replace(/\\n/g, '\n')}
-          engDescription={workEngBody.replace(/\\n/g, '\n')}
-          designers={designers}
-        />
-        <WorkImage images={images} />
-        <DesignerList
-          designers={designers}
-          currentWorkId={parseInt(currentWorkId)}
-        />
-      </section>
+      {!isLoading && (
+        <section css={WorkDetailContainer}>
+          <img
+            src={workBanner}
+            alt={`${workTitle}의 썸네일`}
+            css={thumbnailImg}
+          />
+          <WorkInfo
+            title={workTitle.replace(/\\n/g, '\n')}
+            description={workBody.replace(/\\n/g, '\n')}
+            engDescription={workEngBody.replace(/\\n/g, '\n')}
+            designers={designers}
+          />
+          <WorkImage images={images} />
+          <DesignerList
+            designers={designers}
+            currentWorkId={parseInt(currentWorkId)}
+          />
+        </section>
+      )}
     </PageLayout>
   );
 };

--- a/src/tablet/Designer/page/DesignerPage.tsx
+++ b/src/tablet/Designer/page/DesignerPage.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import useGetDesignerDetail from '../../../libs/hooks/useGetDesignerDetail';
 import DesignerInfo from '../../../mobile/Designer/components/DesignerInfo';
 import Works from '../../../mobile/Designer/components/Works';
@@ -7,8 +7,13 @@ import { ImgBg3Tablet } from '../../assets/image';
 import PageLayout from '../../Common/PageLayout';
 
 const DesignerPage = () => {
-  const { designerId } = useLocation().state;
-  const { designerDetail, isLoading } = useGetDesignerDetail(designerId);
+  const designerName = useParams().name;
+  const designerId =
+    designerName?.split('-')[designerName?.split('-').length - 1];
+  if (!designerId) return;
+  const { designerDetail, isLoading } = useGetDesignerDetail(
+    parseInt(designerId),
+  );
   const { data } = !isLoading && designerDetail;
 
   const { name, engName, major, email, instagram, behance, works } =

--- a/src/tablet/WorkDetail/components/WorkInfo.tsx
+++ b/src/tablet/WorkDetail/components/WorkInfo.tsx
@@ -40,6 +40,7 @@ const mainCss = css`
     margin-bottom: 0.8rem;
 
     ${fonts.desktop_title_semi_24};
+    white-space: pre-wrap;
   }
 
   p:nth-of-type(1) {

--- a/src/tablet/WorkDetail/page/WorkDetailPage.tsx
+++ b/src/tablet/WorkDetail/page/WorkDetailPage.tsx
@@ -20,30 +20,34 @@ const WorkDetailPage = () => {
     parseInt(currentWorkId),
   );
 
+  const isLoading = isWorkDetailLoading || isWorkDesignersLoading;
+
   const { workTitle, workBody, workEngBody, workBanner, images } =
     !isWorkDetailLoading && workDetail.data;
   const designers = !isWorkDesignersLoading && workDesigners.data;
 
   return (
     <PageLayout>
-      <section css={WorkDetailContainer}>
-        <img
-          src={workBanner}
-          alt={`${workTitle}의 썸네일`}
-          css={thumbnailImg}
-        />
-        <WorkInfo
-          title={workTitle}
-          description={workBody.replace(/\\n/g, '\n')}
-          engDescription={workEngBody.replace(/\\n/g, '\n')}
-          designers={designers}
-        />
-        <WorkImage images={images} />
-        <DesignerList
-          designers={designers}
-          currentWorkId={parseInt(currentWorkId)}
-        />
-      </section>
+      {!isLoading && (
+        <section css={WorkDetailContainer}>
+          <img
+            src={workBanner}
+            alt={`${workTitle}의 썸네일`}
+            css={thumbnailImg}
+          />
+          <WorkInfo
+            title={workTitle.replace(/\\n/g, '\n')}
+            description={workBody.replace(/\\n/g, '\n')}
+            engDescription={workEngBody.replace(/\\n/g, '\n')}
+            designers={designers}
+          />
+          <WorkImage images={images} />
+          <DesignerList
+            designers={designers}
+            currentWorkId={parseInt(currentWorkId)}
+          />
+        </section>
+      )}
     </PageLayout>
   );
 };

--- a/src/tablet/WorkDetail/page/WorkDetailPage.tsx
+++ b/src/tablet/WorkDetail/page/WorkDetailPage.tsx
@@ -34,8 +34,8 @@ const WorkDetailPage = () => {
         />
         <WorkInfo
           title={workTitle}
-          description={workBody}
-          engDescription={workEngBody}
+          description={workBody.replace(/\\n/g, '\n')}
+          engDescription={workEngBody.replace(/\\n/g, '\n')}
           designers={designers}
         />
         <WorkImage images={images} />


### PR DESCRIPTION
## ✅ 작업 내용

- [x] 외부 링크에서 디자이너 상세 뷰에 접근 가능하도록 수정
- [x] 서버에서 받아온 데이터 띄어쓰기/ 줄바꿈 반영
- [x] 외부 링크에서 작품 상세 뷰에 접근 가능하도록 수정(develop)
- [x] 유튜브 링크 동작하지 않는 이슈 해결(develop)

## 📌 이슈 사항
### 1️⃣ develop에서 작업
- 위 작업 내용에 `develop`이라고 표시해둔건 dev 브랜치에서 작업한 내용입니다 ..! pr 올라와있는지 모르고 dev에서 바로 작업했는데 그러다보니 도리가 올려둔 pr에 영향이 많이 가더라구요 ,,, ㅠ
- 충돌났던 부분은 모두 해결해두었고, 위 두가지 내용 말고 다른 내용은 요 브랜치에서 작업했습니다 !

<br />

### 2️⃣ 외부 링크에서 디자이너 상세/ 작품 상세 뷰에 접근 가능하도록 수정
- 기존 코드에서는 각종 id를 navigate state로 받아오기 때문에, 외부 링크에서 바로 접근이 안되고 주어진 로직에 따라 차근차근 이동해야만 했는데요 ..!
- 사실 이 부분이 별거 아니긴 하지만, 서비스의 완성도를 너무 떨어트리는 것 같다는 생각이 들어서 외부 링크에서도 바로 접근할 수 있도록 코드를 수정했어요 !!
   1. useLocation으로 받아오던 workId, designerId 값을 url에 포함
   2. useParams로 id 값 가져옴
   3. 요걸 활용해서 서버 통신에 활용

- 중요한 id 값을 url에 포함시키는게 영 ,, 마음에 걸리지만 이 부분은 서버 쪽에서 api를 하나 더 파주거나(이름 정보로 id값을 받아오는 api) id 값이 아닌 다른 값으로 정보를 받아올 수 있도록 현재 api를 수정하지 않는 이상 해결할 수 없는 문제라고 판단했기 때문에, 위와 같은 방법으로 코드를 수정하게 되었어요.
시간이 많았다면 서버에 api 수정을 요청했겠지만, 배포 시기가 얼마남지 않은 시점에서 코드를 수정해달라고 하는건 무리한 요청인 것 같다고 생각했어요,, 

- 개인적으로는 현재 상황에서 최선의 선택이라고 생각하지만, 제가 생각하지 못한 더 좋은 의견있다면 마구 말해주세용 !!! 대환영입니댱 🩷

<br />

### 3️⃣ 서버에서 받아온 데이터 띄어쓰기/ 줄바꿈 반영
- 서버에서 받아온 데이터 중 줄바꿈, 띄어쓰기 반영이 안되는 것들이 있어서, 줄바꿈/ 띄어쓰기 반영하는 정규식과 `white-space: pre-wrap` 적용해뒀습니당

<br />

### 4️⃣ 데탑, 모바일, 태블릿 모두 적용
- 위의 변경사항들은 데탑, 모바일, 태블릿에 모두 반영해두었습니다 ~!